### PR TITLE
Fix typo in English language file

### DIFF
--- a/lang/en/auth_telegram.php
+++ b/lang/en/auth_telegram.php
@@ -28,6 +28,6 @@ $string['pluginname']            = 'Telegram';
 $string['telegrambottoken']      = 'Bot token';
 $string['telegrambottoken_help'] = 'Telegram bot token ';
 $string['hello']                 = 'Hello World';
-$string['notenabled']            = 'Sorry, Teleram authentication plugin is not enabled';
+$string['notenabled']            = 'Sorry, Telegram authentication plugin is not enabled';
 $string['missingtelegramid']     = 'Missing telegramid';
 


### PR DESCRIPTION
## Summary
- correct Telegram spelling in English notenabled string

## Testing
- `php -l lang/en/auth_telegram.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bdd3dad483219e6dde134376fb0e