### PR TITLE
Add missing profile fields page

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,11 +76,44 @@ function user_authentication($userinfo) {
         ? \auth_telegram\telegram::get_user($userinfo['username'])
         : \auth_telegram\telegram::create_user($userinfo);
 
+    $missing = auth_telegram_get_missing_fields($user);
+    if (!empty($missing)) {
+        $_SESSION['auth_telegram_pending_user'] = $user;
+        $_SESSION['auth_telegram_missing_fields'] = $missing;
+        redirect(new moodle_url('/auth/telegram/missingfields.php'));
+    }
+
     \auth_telegram\telegram::user_login($user);
 
     // Mark the session as logged in via Telegram without overwriting existing data.
     $_SESSION['logged-in'] = true;
     $_SESSION['telegram_id'] = $userinfo['id'];
+}
+
+/**
+ * Check required and custom profile fields for missing values.
+ *
+ * @param \stdClass $user
+ * @return array List of missing field names.
+ */
+function auth_telegram_get_missing_fields($user): array {
+    $missingfields = [];
+
+    $requiredfields = ['firstname', 'lastname', 'email', 'city', 'country'];
+    foreach ($requiredfields as $field) {
+        if (empty($user->$field)) {
+            $missingfields[] = get_string($field);
+        }
+    }
+
+    $profilefields = profile_get_user_fields_with_data($user->id);
+    foreach ($profilefields as $field) {
+        if ($field->is_required() && empty($field->data)) {
+            $missingfields[] = format_string($field->field->name);
+        }
+    }
+
+    return $missingfields;
 }
 
 

--- a/lang/ar/auth_telegram.php
+++ b/lang/ar/auth_telegram.php
@@ -30,4 +30,6 @@ $string['telegrambottoken_help'] = ' رمز بوت التليجرام';
 $string['hello']                 = 'مرحباااا';
 $string['notenabled']            = 'عذرًا ، لم يتم تمكين البرنامج المساعد المصادق على التلغرام';
 $string['missingtelegramid']     = 'معرف التلغرام مفقود';
+$string['missingfieldsheader']   = 'مطلوب معلومات إضافية للملف الشخصي';
+$string['missingfieldsmessage']  = 'حقول الملف الشخصي المطلوبة التالية مفقودة:';
 

--- a/lang/en/auth_telegram.php
+++ b/lang/en/auth_telegram.php
@@ -30,4 +30,6 @@ $string['telegrambottoken_help'] = 'Telegram bot token ';
 $string['hello']                 = 'Hello World';
 $string['notenabled']            = 'Sorry, Telegram authentication plugin is not enabled';
 $string['missingtelegramid']     = 'Missing telegramid';
+$string['missingfieldsheader']   = 'Additional profile information required';
+$string['missingfieldsmessage']  = 'The following required profile fields are missing:';
 

--- a/missingfields.php
+++ b/missingfields.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+require_once('../../config.php');
+require_once($CFG->dirroot . '/user/profile/lib.php');
+require_once($CFG->dirroot . '/user/lib.php');
+
+$PAGE->set_url(new moodle_url('/auth/telegram/missingfields.php'));
+$PAGE->set_context(context_system::instance());
+
+$user = $_SESSION['auth_telegram_pending_user'] ?? null;
+$missing = $_SESSION['auth_telegram_missing_fields'] ?? [];
+
+if (!$user || empty($missing)) {
+    redirect('/');
+}
+
+if (optional_param('continue', 0, PARAM_BOOL)) {
+    \auth_telegram\telegram::user_login($user);
+    $_SESSION['logged-in'] = true;
+    $_SESSION['telegram_id'] = $user->username;
+    unset($_SESSION['auth_telegram_pending_user']);
+    unset($_SESSION['auth_telegram_missing_fields']);
+    exit;
+}
+
+$PAGE->set_heading(get_string('missingfieldsheader', 'auth_telegram'));
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('missingfieldsheader', 'auth_telegram'));
+echo html_writer::tag('p', get_string('missingfieldsmessage', 'auth_telegram'));
+echo html_writer::alist($missing);
+echo $OUTPUT->single_button(
+    new moodle_url('/auth/telegram/missingfields.php', ['continue' => 1]),
+    get_string('continue')
+);
+echo $OUTPUT->footer();


### PR DESCRIPTION
## Summary
- Detect missing required and custom profile fields after Telegram callback
- Show a missing fields page listing absent fields before final login
- Add English and Arabic strings for the new page

## Testing
- `php -l index.php`
- `php -l missingfields.php`
- `php -l lang/en/auth_telegram.php`
- `php -l lang/ar/auth_telegram.php`


------
https://chatgpt.com/codex/tasks/task_e_68adc741e29c83218d3952e6c6ffabfc